### PR TITLE
Address forms clean up input values after verification

### DIFF
--- a/example/src/AddressFormDemo.js
+++ b/example/src/AddressFormDemo.js
@@ -1,6 +1,6 @@
 // External Dependencies
 import React, { useState } from 'react';
-import { AddressForm, verify } from '@lob/react-address-autocomplete'
+import { AddressForm } from '@lob/react-address-autocomplete'
 
 // Internal Dependencies
 import VerificationResult from './VerificationResult'
@@ -25,10 +25,9 @@ const AddressFormDemo = ({ apiKey }) => {
     resetApiResult()
   }
 
-  const handleSubmit = () =>
+  const handleSubmit = verificationResult =>
     resetApiResult()
-      .then(() => verify(apiKey, selectedResult.value))
-      .then(res => setVerificationResult(res))
+      .then(() => setVerificationResult(verificationResult))
       .catch(err => setErrorMessage(err.message))
 
   return (
@@ -38,13 +37,12 @@ const AddressFormDemo = ({ apiKey }) => {
         apiKey={apiKey}
         onFieldChange={handleChange}
         onSelection={handleSelect}
+        onSubmit={handleSubmit}
+        submitLabel="Verify"
+        styles={{
+          'lob-submit': { width: '100%' }
+        }}
       />
-      <button
-        onClick={handleSubmit}
-        style={{ width: '100%' }}
-      >
-        Verify
-      </button>
       <VerificationResult apiResponse={verificationResult} error={errorMessage} />
     </div>
   );

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -6,7 +6,7 @@ import AddressFormDemo from './AddressFormDemo'
 // import DomesticDemo from './DomesticDemo'
 // import InternationalDemo from './InternationalDemo'
 
-const API_KEY = 'live_pub_16d30adbb46a1c360ebf7d1e6b48361'
+const API_KEY = 'YOUR_API_KEY_HERE'
 
 const App = () => {
 
@@ -18,8 +18,8 @@ const App = () => {
         alt='Lob'
       />
       <h1>React Address Autocomplete Demo</h1>
-      {/* <DomesticDemo apiKey={API_KEY} />
-      <InternationalDemo apiKey={API_KEY} /> */}
+      {/* <DomesticDemo apiKey={API_KEY} /> */}
+      {/* <InternationalDemo apiKey={API_KEY} /> */}
       <AddressFormDemo apiKey={API_KEY} />
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@lob/react-address-autocomplete",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@lob/react-address-autocomplete",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "license": "MIT",
             "dependencies": {
                 "base-64": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "cross-env": "^7.0.2",
                 "eslint": "^8.14.0",
                 "eslint-config-prettier": "^8.3.0",
-                "eslint-config-react-app": "^7.0.1",
                 "eslint-config-standard-react": "^11.0.1",
                 "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-promise": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lob/react-address-autocomplete",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "A collection of components and utility functions for verifying and suggesting addresses using Lob",
     "author": "Lob",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "cross-env": "^7.0.2",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.3.0",
-        "eslint-config-react-app": "^7.0.1",
         "eslint-config-standard-react": "^11.0.1",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-promise": "^5.1.0",

--- a/src/AddressForm/AddressForm.js
+++ b/src/AddressForm/AddressForm.js
@@ -26,14 +26,11 @@ const customStyles = {
  * @param {String} apiKey - Public API key to your Lob account.
  * @param {Array?} children - The elements to render between the address form inputs and submit button
  * @param {Boolean} hideSubmitButton - Hides the submit button and its behavior
- * @param {Function} onInputChange -
- *  Callback when any input value changes. Includes both the event object and address form.
- *  Use event.target.id to determine which component is being updated.
- * @param {Function} onSelection -
- *  Callback when the select component changes.
- * @param {Function} onSubmit -
- *  Callback after the submit button is clicked and the form inputs are updated. Passes the
- *  verification result from the API.
+ * @param {Function} onInputChange - Callback when any input value changes. Includes both the event
+ *  object and address form. Use event.target.id to determine which component is being updated.
+ * @param {Function} onSelection - Callback when the select component changes.
+ * @param {Function} onSubmit - Callback after the submit button is clicked and the form inputs
+ *  are updated. Passes the verification result from the API.
  * @param {Object} styles - Override the default styles by providing an object similar to the
  *  styling framework used by react-select. Each key corresponds to a component and maps to a
  *  function that returns the new styles.lob_ Here is an example:
@@ -52,7 +49,7 @@ const customStyles = {
  *  - lob_submit
  *
  *  For more details visit https://react-select.com/styles
- * @param {Node} submitButton -
+ * @param {String} submitButtonLabel
  */
 const AddressForm = ({
   apiKey,
@@ -62,6 +59,7 @@ const AddressForm = ({
   onSelection = () => {},
   onSubmit = () => {},
   styles = {},
+  submitButtonLabel = 'Submit',
   ...additionalProps
 }) => {
   const [form, setForm] = useState(defaultForm)
@@ -198,12 +196,14 @@ const AddressForm = ({
         />
       </div>
       {children}
-      <button
-        onClick={handleSubmit}
-        style={mergedStyles.lob_submit}
-      >
-        Verify
-      </button>
+      {!hideSubmitButton && (
+        <button
+          onClick={handleSubmit}
+          style={mergedStyles.lob_submit}
+        >
+          {submitButtonLabel}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/AddressForm/AddressForm.js
+++ b/src/AddressForm/AddressForm.js
@@ -4,6 +4,7 @@
 import React, { useState } from 'react'
 
 // Internal Dependencies
+import { verify } from '../verify'
 import Autocomplete from '../Autocomplete'
 import useMergedStyles from './useMergedStyles'
 
@@ -22,12 +23,17 @@ const customStyles = {
 /**
  * Similar to Autocomplete except each address component is given its own input. Autocomplete
  * occurs on the primary line but the results are inserted into each component.
- * @param {string} apiKey - Public API key to your Lob account.
- * @param {onSelection?} onSelection -
- *  Callback function when the select component changes.
- * @param {onInputChange?} onInputChange -
- *  Callback function when any input value changes. Includes both the event object and address form.
+ * @param {String} apiKey - Public API key to your Lob account.
+ * @param {Array?} children - The elements to render between the address form inputs and submit button
+ * @param {Boolean} hideSubmitButton - Hides the submit button and its behavior
+ * @param {Function} onInputChange -
+ *  Callback when any input value changes. Includes both the event object and address form.
  *  Use event.target.id to determine which component is being updated.
+ * @param {Function} onSelection -
+ *  Callback when the select component changes.
+ * @param {Function} onSubmit -
+ *  Callback after the submit button is clicked and the form inputs are updated. Passes the
+ *  verification result from the API.
  * @param {Object} styles - Override the default styles by providing an object similar to the
  *  styling framework used by react-select. Each key corresponds to a component and maps to a
  *  function that returns the new styles.lob_ Here is an example:
@@ -43,13 +49,18 @@ const customStyles = {
  *  - lob_input
  *  - lob_label
  *  - lob_row
+ *  - lob_submit
  *
  *  For more details visit https://react-select.com/styles
+ * @param {Node} submitButton -
  */
 const AddressForm = ({
   apiKey,
+  children,
+  hideSubmitButton = false,
   onFieldChange = () => {},
   onSelection = () => {},
+  onSubmit = () => {},
   styles = {},
   ...additionalProps
 }) => {
@@ -97,6 +108,29 @@ const AddressForm = ({
       }
     })
   }
+
+  const handleSubmit = () =>
+    verify(apiKey, form)
+    .then(verificationResult => {
+      const {
+        primary_line,
+        secondary_line,
+        components: {
+          city,
+          state,
+          zip_code,
+          zip_code_plus_4
+        }
+      } = verificationResult
+      setForm({
+        primary_line,
+        secondary_line,
+        city,
+        state,
+        zip_code: `${zip_code}-${zip_code_plus_4}`,
+      })
+      onSubmit(verificationResult)
+    })
 
   const mergedStyles = useMergedStyles(styles, false /* isInternational */)
 
@@ -163,6 +197,13 @@ const AddressForm = ({
           value={zip_code}
         />
       </div>
+      {children}
+      <button
+        onClick={handleSubmit}
+        style={mergedStyles.lob_submit}
+      >
+        Verify
+      </button>
     </div>
   )
 }

--- a/src/AddressForm/AddressForm.js
+++ b/src/AddressForm/AddressForm.js
@@ -24,7 +24,8 @@ const customStyles = {
  * Similar to Autocomplete except each address component is given its own input. Autocomplete
  * occurs on the primary line but the results are inserted into each component.
  * @param {String} apiKey - Public API key to your Lob account.
- * @param {Array?} children - The elements to render between the address form inputs and submit button
+ * @param {Array?} children - These elements get rendered between the address form inputs and
+ *  submit button
  * @param {Boolean} hideSubmitButton - Hides the submit button and its behavior
  * @param {Function} onInputChange - Callback when any input value changes. Includes both the event
  *  object and address form. Use event.target.id to determine which component is being updated.
@@ -108,24 +109,18 @@ const AddressForm = ({
   }
 
   const handleSubmit = () =>
-    verify(apiKey, form)
-    .then(verificationResult => {
+    verify(apiKey, form).then((verificationResult) => {
       const {
         primary_line,
         secondary_line,
-        components: {
-          city,
-          state,
-          zip_code,
-          zip_code_plus_4
-        }
+        components: { city, state, zip_code, zip_code_plus_4 }
       } = verificationResult
       setForm({
         primary_line,
         secondary_line,
         city,
         state,
-        zip_code: `${zip_code}-${zip_code_plus_4}`,
+        zip_code: `${zip_code}-${zip_code_plus_4}`
       })
       onSubmit(verificationResult)
     })
@@ -197,10 +192,7 @@ const AddressForm = ({
       </div>
       {children}
       {!hideSubmitButton && (
-        <button
-          onClick={handleSubmit}
-          style={mergedStyles.lob_submit}
-        >
+        <button onClick={handleSubmit} style={mergedStyles.lob_submit}>
           {submitButtonLabel}
         </button>
       )}

--- a/src/AddressForm/AddressFormInternational.js
+++ b/src/AddressForm/AddressFormInternational.js
@@ -4,6 +4,7 @@
 import React, { useState } from 'react'
 
 // Internal Dependencies
+import { verify } from '../verify'
 import CountrySelect from '../CountrySelect'
 import useMergedStyles from './useMergedStyles'
 
@@ -19,7 +20,8 @@ const defaultForm = {
  * Renders a group of inputs for each address component including a select input for country code.
  * Does not perform any address autocompletion.
  * @param {String?} apiKey - Public API key to your Lob account.
- * @param {Array?} children - The elements to render between the address form inputs and submit button
+ * @param {Array?} children - These elements get rendered between the address form inputs and
+ *  submit button
  * @param {Boolean} hideSubmitButton - Hides the submit button and its behavior
  * @param {Function?} onInputChange - Callback when any input value changes. Use e.target.id
  *  to determine which component is being updated.
@@ -49,8 +51,9 @@ const AddressFormInternational = ({
   children,
   hideSubmitButton = false,
   onFieldChange = () => {},
+  onSubmit = () => {},
   styles = {},
-  submitButtonLabel = 'Submit',
+  submitButtonLabel = 'Submit'
 }) => {
   const [form, setForm] = useState(defaultForm)
   const { primary_line, secondary_line, city, state, zip_code, country } = form
@@ -64,31 +67,28 @@ const AddressFormInternational = ({
     // apiKey wasn't used is previous versions of AddressFormInternational so we made the prop
     // optional to not introduce a breaking change.
     if (!apiKey) {
-      console.error('[@lob/react-address-autocomplete] AddressFormInternational requires props apiKey for verifications')
+      console.error(
+        '[@lob/react-address-autocomplete] ' +
+        'AddressFormInternational requires props apiKey for verifications'
+      )
       return
     }
 
-    verify(apiKey, form)
-      .then(verificationResult => {
-        const {
-          primary_line,
-          secondary_line,
-          components: {
-            city,
-            state,
-            zip_code,
-            zip_code_plus_4
-          }
-        } = verificationResult
-        setForm({
-          primary_line,
-          secondary_line,
-          city,
-          state,
-          zip_code: `${zip_code}-${zip_code_plus_4}`,
-        })
-        onSubmit(verificationResult)
+    verify(apiKey, form).then((verificationResult) => {
+      const {
+        primary_line,
+        secondary_line,
+        components: { city, state, zip_code, zip_code_plus_4 }
+      } = verificationResult
+      setForm({
+        primary_line,
+        secondary_line,
+        city,
+        state,
+        zip_code: `${zip_code}-${zip_code_plus_4}`
       })
+      onSubmit(verificationResult)
+    })
   }
 
   const mergedStyles = useMergedStyles(styles, true /* isInternational */)
@@ -163,10 +163,7 @@ const AddressFormInternational = ({
       </div>
       {children}
       {!hideSubmitButton && (
-        <button
-          onClick={handleSubmit}
-          style={mergedStyles.lob_submit}
-        >
+        <button onClick={handleSubmit} style={mergedStyles.lob_submit}>
           {submitButtonLabel}
         </button>
       )}

--- a/src/AddressForm/AddressFormInternational.js
+++ b/src/AddressForm/AddressFormInternational.js
@@ -4,7 +4,7 @@
 import React, { useState } from 'react'
 
 // Internal Dependencies
-import { verify } from '../verify'
+import { verifyInternational } from '../verify'
 import CountrySelect from '../CountrySelect'
 import useMergedStyles from './useMergedStyles'
 
@@ -13,7 +13,7 @@ const defaultForm = {
   secondary_line: '',
   city: '',
   state: '',
-  zip_code: ''
+  postal_code: ''
 }
 
 /**
@@ -23,7 +23,7 @@ const defaultForm = {
  * @param {Array?} children - These elements get rendered between the address form inputs and
  *  submit button
  * @param {Boolean} hideSubmitButton - Hides the submit button and its behavior
- * @param {Function?} onInputChange - Callback when any input value changes. Use e.target.id
+ * @param {Function?} onFieldChange - Callback when any input value changes. Use e.target.id
  *  to determine which component is being updated.
  * @param {Function?} onSubmit - Callback after the submit button is clicked and the form inputs
  *  are updated. Passes the verification result from the API.
@@ -56,7 +56,7 @@ const AddressFormInternational = ({
   submitButtonLabel = 'Submit'
 }) => {
   const [form, setForm] = useState(defaultForm)
-  const { primary_line, secondary_line, city, state, zip_code, country } = form
+  const { primary_line, secondary_line, city, state, postal_code, country } = form
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.id]: e.target.value })
@@ -74,18 +74,18 @@ const AddressFormInternational = ({
       return
     }
 
-    verify(apiKey, form).then((verificationResult) => {
+    verifyInternational(apiKey, form, form.country).then((verificationResult) => {
       const {
         primary_line,
         secondary_line,
-        components: { city, state, zip_code, zip_code_plus_4 }
+        components: { city, state, postal_code }
       } = verificationResult
       setForm({
         primary_line,
         secondary_line,
         city,
         state,
-        zip_code: `${zip_code}-${zip_code_plus_4}`
+        postal_code
       })
       onSubmit(verificationResult)
     })
@@ -140,14 +140,14 @@ const AddressFormInternational = ({
         />
       </div>
       <div style={mergedStyles.lob_row}>
-        <label style={mergedStyles.lob_label} htmlFor='zip_code'>
+        <label style={mergedStyles.lob_label} htmlFor='postal_code'>
           Zip / Postal Code
         </label>
         <input
           style={{ ...mergedStyles.lob_input }}
-          id='zip_code'
+          id='postal_code'
           onChange={handleChange}
-          value={zip_code}
+          value={postal_code}
         />
       </div>
       <div style={mergedStyles.lob_row}>

--- a/src/AddressForm/AddressFormInternational.js
+++ b/src/AddressForm/AddressFormInternational.js
@@ -56,7 +56,8 @@ const AddressFormInternational = ({
   submitButtonLabel = 'Submit'
 }) => {
   const [form, setForm] = useState(defaultForm)
-  const { primary_line, secondary_line, city, state, postal_code, country } = form
+  const { primary_line, secondary_line, city, state, postal_code, country } =
+    form
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.id]: e.target.value })
@@ -69,26 +70,28 @@ const AddressFormInternational = ({
     if (!apiKey) {
       console.error(
         '[@lob/react-address-autocomplete] ' +
-        'AddressFormInternational requires props apiKey for verifications'
+          'AddressFormInternational requires props apiKey for verifications'
       )
       return
     }
 
-    verifyInternational(apiKey, form, form.country).then((verificationResult) => {
-      const {
-        primary_line,
-        secondary_line,
-        components: { city, state, postal_code }
-      } = verificationResult
-      setForm({
-        primary_line,
-        secondary_line,
-        city,
-        state,
-        postal_code
-      })
-      onSubmit(verificationResult)
-    })
+    verifyInternational(apiKey, form, form.country).then(
+      (verificationResult) => {
+        const {
+          primary_line,
+          secondary_line,
+          components: { city, state, postal_code }
+        } = verificationResult
+        setForm({
+          primary_line,
+          secondary_line,
+          city,
+          state,
+          postal_code
+        })
+        onSubmit(verificationResult)
+      }
+    )
   }
 
   const mergedStyles = useMergedStyles(styles, true /* isInternational */)

--- a/src/api.js
+++ b/src/api.js
@@ -48,6 +48,7 @@ export const postVerifyInternationalAddress = (
   address,
   countryCode
 ) => {
+  const payload = typeof address === 'string' ? { address } : address
   const url = new URL('https://api.lob.com/v1/intl_verifications')
   url.searchParams.append('av_integration_origin', window.location.href)
   url.searchParams.append('integration', 'react-address-autocomplete')
@@ -57,7 +58,7 @@ export const postVerifyInternationalAddress = (
       Authorization: `Basic ${base64.encode(apiKey + ':')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ address, country: countryCode })
+    body: JSON.stringify({ ...payload, country: countryCode })
   }
 
   return fetch(url, init)

--- a/src/verify.js
+++ b/src/verify.js
@@ -22,6 +22,30 @@ const processApiResponse = (apiResponse) =>
  * @param {string} zip_code
  */
 
+
+const validateArguments = (apiKey, address, countryCode = null) => {
+  if (!Object.keys(address || {}).length) {
+    return new Error('Empty address was passed to verify function')
+  }
+
+  if (!apiKey.length) {
+    return new Error('Missing API key')
+  }
+
+  if (countryCode) {
+    if (typeof countryCode !== 'string') {
+      return new Error('Expected countryCode to be of type string')
+    }
+    if (/[A-Z]{2}/.test(countryCode) === false) {
+      return new Error(
+        'countryCode must be a 2 letter country short-name code (ISO 3166)'
+      )
+    }
+  }
+
+  return null
+}
+
 /**
  * Checks the deliverability of a given address and provides meta data such as geo coordinates,
  * county, building type, etc.
@@ -31,15 +55,9 @@ const processApiResponse = (apiResponse) =>
  *  https://docs.lob.com/#operation/us_verification
  */
 export const verify = (apiKey, address) => {
-  // Validate arguments
-  if (!Object.keys(address || {}).length) {
-    return Promise.reject(
-      new Error('Empty address was passed to verify function')
-    )
-  }
-
-  if (!apiKey.length) {
-    return Promise.reject(new Error('Missing API key'))
+  const error = validateArguments(apiKey, address)
+  if (error) {
+    return Promise.reject(error)
   }
 
   let payloadAddress = address
@@ -69,29 +87,9 @@ export const verify = (apiKey, address) => {
  *  https://docs.lob.com/#operation/us_verification
  */
 export const verifyInternational = (apiKey, address, countryCode) => {
-  // Validate arguments
-  if (!Object.keys(address || {}).length) {
-    return Promise.reject(
-      new Error('Empty address was passed to verify function')
-    )
-  }
-
-  if (!apiKey.length) {
-    return Promise.reject(new Error('Missing API key'))
-  }
-
-  if (typeof countryCode !== 'string') {
-    return Promise.reject(
-      new Error('Expected countryCode to be of type string')
-    )
-  }
-
-  if (/[A-Z]{2}/.test(countryCode) === false) {
-    return Promise.reject(
-      new Error(
-        'countryCode must be a 2 letter country short-name code (ISO 3166)'
-      )
-    )
+  const error = validateArguments(apiKey, address, countryCode)
+  if (error) {
+    return Promise.reject(error)
   }
 
   // Send request to Lob and let user decide how to handle the response

--- a/src/verify.js
+++ b/src/verify.js
@@ -22,8 +22,7 @@ const processApiResponse = (apiResponse) =>
  * @param {string} zip_code
  */
 
-
-const validateArguments = (apiKey, address, countryCode = null) => {
+const validateArguments = (apiKey, address, countryCode, isInternational) => {
   if (!Object.keys(address || {}).length) {
     return new Error('Empty address was passed to verify function')
   }
@@ -32,7 +31,7 @@ const validateArguments = (apiKey, address, countryCode = null) => {
     return new Error('Missing API key')
   }
 
-  if (countryCode) {
+  if (isInternational) {
     if (typeof countryCode !== 'string') {
       return new Error('Expected countryCode to be of type string')
     }
@@ -55,7 +54,7 @@ const validateArguments = (apiKey, address, countryCode = null) => {
  *  https://docs.lob.com/#operation/us_verification
  */
 export const verify = (apiKey, address) => {
-  const error = validateArguments(apiKey, address)
+  const error = validateArguments(apiKey, address, null, false)
   if (error) {
     return Promise.reject(error)
   }
@@ -87,7 +86,8 @@ export const verify = (apiKey, address) => {
  *  https://docs.lob.com/#operation/us_verification
  */
 export const verifyInternational = (apiKey, address, countryCode) => {
-  const error = validateArguments(apiKey, address, countryCode)
+  const error = validateArguments(apiKey, address, countryCode, true)
+
   if (error) {
     return Promise.reject(error)
   }


### PR DESCRIPTION
[AV-3325](https://lobsters.atlassian.net/browse/AV-3325)

`AddressForm` and `AddressFormInternational` now control their own submit buttons. This way we can update the form inputs after users submits their form. The submit button can be styled using the style key `lob_submit_button` and is rendered after the form's children (e.g. additional form inputs).
![addressformupdate](https://user-images.githubusercontent.com/5534079/170557208-8a6381fb-b667-4cdb-8bb8-0fd84c0c3ad2.gif)

